### PR TITLE
Update dependency on `api-auth`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ gemspec
 
 group :development, :test do
   gem 'coveralls', require: false
+  gem 'pry'
 end

--- a/mifiel.gemspec
+++ b/mifiel.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_runtime_dependency 'activesupport'
-  spec.add_runtime_dependency 'api-auth', '~> 1.4'
+  spec.add_runtime_dependency 'api-auth', '~> 2.0'
   spec.add_runtime_dependency 'flexirest', '~> 1.6'
   spec.add_runtime_dependency 'json', '>= 1.8'
   spec.add_runtime_dependency 'rest-client', '>= 1.8'


### PR DESCRIPTION
## Add pry to Gemfile

Add pry to Gemfile so you can `bundle exec rspec` (if you don't `bundle exec`, you could get random versions of the gems, but if you do, then it can't load `pry` as it's not specified as a development dependency)

## Update ApiAuth to `~> 2.0`

ApiAuth v1 has insecure defaults and uses deprecated Faraday features which lead to test spam. This bumps it to ~>2.0, because that allows for versions which use Faraday correctly, and fixes the security vulnerabilities.

Example of the Faraday deprecation warning from Mifiel's test suite:

<img width="1248" alt="Screen Shot 2022-02-08 at 4 09 42 PM" src="https://user-images.githubusercontent.com/77495/153097703-f49bbeac-4dec-4670-82f1-90629591dd2f.png">

* Link to v2.0 in the changelog ([here](https://github.com/mgomes/api_auth/blob/master/CHANGELOG.md#200-2016-05-11))
* Link to the security vulnearability ([here](https://github.com/mgomes/api_auth/blob/master/CHANGELOG.md#140-2015-12-16))


Co-authored-by: Angel Malavar <angel.malavar@gmail.com>