### PR TITLE
Upgrade/api auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ gemspec
 
 group :development, :test do
   gem 'coveralls', require: false
+  gem 'pry'
 end

--- a/lib/mifiel/certificate.rb
+++ b/lib/mifiel/certificate.rb
@@ -16,7 +16,7 @@ module Mifiel
         },
         ssl_version: 'SSLv23'
       )
-      req = ApiAuth.sign!(rest_request, Mifiel.config.app_id, Mifiel.config.app_secret, { override_http_method: :post, with_http_method: true })
+      req = ApiAuth.sign!(rest_request, Mifiel.config.app_id, Mifiel.config.app_secret, { override_http_method: :post })
       Mifiel::Certificate.new(JSON.parse(req.execute))
     end
   end

--- a/lib/mifiel/certificate.rb
+++ b/lib/mifiel/certificate.rb
@@ -16,7 +16,7 @@ module Mifiel
         },
         ssl_version: 'SSLv23'
       )
-      req = ApiAuth.sign!(rest_request, Mifiel.config.app_id, Mifiel.config.app_secret, { override_http_method: :post })
+      req = ApiAuth.sign!(rest_request, Mifiel.config.app_id, Mifiel.config.app_secret, { override_http_method: :post, with_http_method: true })
       Mifiel::Certificate.new(JSON.parse(req.execute))
     end
   end

--- a/lib/mifiel/certificate.rb
+++ b/lib/mifiel/certificate.rb
@@ -16,7 +16,7 @@ module Mifiel
         },
         ssl_version: 'SSLv23'
       )
-      req = ApiAuth.sign!(rest_request, Mifiel.config.app_id, Mifiel.config.app_secret)
+      req = ApiAuth.sign!(rest_request, Mifiel.config.app_id, Mifiel.config.app_secret, { override_http_method: :post })
       Mifiel::Certificate.new(JSON.parse(req.execute))
     end
   end

--- a/lib/mifiel/document.rb
+++ b/lib/mifiel/document.rb
@@ -74,7 +74,7 @@ module Mifiel
         payload: payload,
         ssl_version: 'SSLv23'
       )
-      req = ApiAuth.sign!(rest_request, Mifiel.config.app_id, Mifiel.config.app_secret, { override_http_method: method, with_http_method: true })
+      req = ApiAuth.sign!(rest_request, Mifiel.config.app_id, Mifiel.config.app_secret, { override_http_method: method })
       req.execute
     end
 

--- a/lib/mifiel/document.rb
+++ b/lib/mifiel/document.rb
@@ -74,7 +74,7 @@ module Mifiel
         payload: payload,
         ssl_version: 'SSLv23'
       )
-      req = ApiAuth.sign!(rest_request, Mifiel.config.app_id, Mifiel.config.app_secret)
+      req = ApiAuth.sign!(rest_request, Mifiel.config.app_id, Mifiel.config.app_secret, { override_http_method: method })
       req.execute
     end
 

--- a/lib/mifiel/document.rb
+++ b/lib/mifiel/document.rb
@@ -74,7 +74,7 @@ module Mifiel
         payload: payload,
         ssl_version: 'SSLv23'
       )
-      req = ApiAuth.sign!(rest_request, Mifiel.config.app_id, Mifiel.config.app_secret, { override_http_method: method })
+      req = ApiAuth.sign!(rest_request, Mifiel.config.app_id, Mifiel.config.app_secret, { override_http_method: method, with_http_method: true })
       req.execute
     end
 

--- a/lib/mifiel/user.rb
+++ b/lib/mifiel/user.rb
@@ -22,7 +22,7 @@ module Mifiel
         },
         ssl_version: 'SSLv23'
       )
-      req = ApiAuth.sign!(rest_request, Mifiel.config.app_id, Mifiel.config.app_secret, { override_http_method: :post })
+      req = ApiAuth.sign!(rest_request, Mifiel.config.app_id, Mifiel.config.app_secret, { override_http_method: :post, with_http_method: true })
       Mifiel::User.new(JSON.parse(req.execute))
     end
   end

--- a/lib/mifiel/user.rb
+++ b/lib/mifiel/user.rb
@@ -22,7 +22,7 @@ module Mifiel
         },
         ssl_version: 'SSLv23'
       )
-      req = ApiAuth.sign!(rest_request, Mifiel.config.app_id, Mifiel.config.app_secret)
+      req = ApiAuth.sign!(rest_request, Mifiel.config.app_id, Mifiel.config.app_secret, { override_http_method: :post })
       Mifiel::User.new(JSON.parse(req.execute))
     end
   end

--- a/lib/mifiel/user.rb
+++ b/lib/mifiel/user.rb
@@ -22,7 +22,7 @@ module Mifiel
         },
         ssl_version: 'SSLv23'
       )
-      req = ApiAuth.sign!(rest_request, Mifiel.config.app_id, Mifiel.config.app_secret, { override_http_method: :post, with_http_method: true })
+      req = ApiAuth.sign!(rest_request, Mifiel.config.app_id, Mifiel.config.app_secret, { override_http_method: :post })
       Mifiel::User.new(JSON.parse(req.execute))
     end
   end

--- a/mifiel.gemspec
+++ b/mifiel.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_runtime_dependency 'activesupport'
-  spec.add_runtime_dependency 'api-auth', '~> 2.5'
+  spec.add_runtime_dependency 'api-auth', '~> 2.1'
   spec.add_runtime_dependency 'flexirest', '~> 1.6'
   spec.add_runtime_dependency 'json', '>= 1.8'
   spec.add_runtime_dependency 'rest-client', '>= 1.8'

--- a/mifiel.gemspec
+++ b/mifiel.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_runtime_dependency 'activesupport'
-  spec.add_runtime_dependency 'api-auth', '~> 2.1'
+  spec.add_runtime_dependency 'api-auth', '~> 2.5'
   spec.add_runtime_dependency 'flexirest', '~> 1.6'
   spec.add_runtime_dependency 'json', '>= 1.8'
   spec.add_runtime_dependency 'rest-client', '>= 1.8'

--- a/mifiel.gemspec
+++ b/mifiel.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_runtime_dependency 'activesupport'
-  spec.add_runtime_dependency 'api-auth', '~> 1.4'
+  spec.add_runtime_dependency 'api-auth', '~> 2.5'
   spec.add_runtime_dependency 'flexirest', '~> 1.6'
   spec.add_runtime_dependency 'json', '>= 1.8'
   spec.add_runtime_dependency 'rest-client', '>= 1.8'

--- a/mifiel.gemspec
+++ b/mifiel.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_runtime_dependency 'activesupport'
-  spec.add_runtime_dependency 'api-auth', '~> 2.5'
+  spec.add_runtime_dependency 'api-auth', '>= 2.5'
   spec.add_runtime_dependency 'flexirest', '~> 1.6'
   spec.add_runtime_dependency 'json', '>= 1.8'
   spec.add_runtime_dependency 'rest-client', '>= 1.8'


### PR DESCRIPTION
- Upgrades api-auth gem

As suggested by: https://github.com/Mifiel/ruby-api-client/pull/18

Options could be:
`options = { override_http_method: nil, digest: 'sha1' }.merge(options)`